### PR TITLE
Remove preloading nav.js, additional enhancements to offcanvas

### DIFF
--- a/faqs.html
+++ b/faqs.html
@@ -13,7 +13,6 @@
       rel="preload"
       src="../../node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
     ></script>
-    <script rel="preload" src="/src/scripts/nav.js"></script>
     <link rel="stylesheet" href="/src/scss/Custom.css" />
     <title>FAQs</title>
   </head>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
       rel="preload"
       src="../../node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
     ></script>
-    <script rel="preload" src="/src/scripts/nav.js"></script>
     <link rel="stylesheet" href="/src/scss/Custom.css" />
     <title>Home</title>
   </head>
@@ -21,11 +20,7 @@
   <body>
     <div class="container-fluid">
       <div class="row">
-        <script
-          id="replace_with_navbar"
-          src="/src/scripts/nav.js"
-          defer
-        ></script>
+        <script id="replace_with_navbar" src="/src/scripts/nav.js"></script>
       </div>
       <div class="row">
         <figure>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,11 @@
   <body>
     <div class="container-fluid">
       <div class="row">
-        <script id="replace_with_navbar" src="/src/scripts/nav.js"></script>
+        <script
+          id="replace_with_navbar"
+          src="/src/scripts/nav.js"
+          defer
+        ></script>
       </div>
       <div class="row">
         <figure>

--- a/our-story.html
+++ b/our-story.html
@@ -13,7 +13,6 @@
       rel="preload"
       src="../../node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
     ></script>
-    <script rel="preload" src="/src/scripts/nav.js"></script>
     <link rel="stylesheet" href="/src/scss/Custom.css" />
     <title>Our Story</title>
   </head>

--- a/registry.html
+++ b/registry.html
@@ -13,7 +13,6 @@
       rel="preload"
       src="../../node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
     ></script>
-    <script rel="preload" src="/src/scripts/nav.js"></script>
     <link rel="stylesheet" href="/src/scss/Custom.css" />
     <title>Registry</title>
   </head>

--- a/rsvp.html
+++ b/rsvp.html
@@ -13,7 +13,6 @@
       rel="preload"
       src="../../node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
     ></script>
-    <script rel="preload" src="/src/scripts/nav.js"></script>
     <link rel="stylesheet" href="/src/scss/Custom.css" />
     <title>RSVP</title>
   </head>

--- a/src/scss/Custom.css
+++ b/src/scss/Custom.css
@@ -11968,8 +11968,12 @@ textarea.form-control-lg {
 .offcanvas-backdrop.show {
   opacity: 1;
   background-color: rgba(15, 23, 42, 0.5);
-  -webkit-backdrop-filter: blur(8px);
-          backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(4px);
+          backdrop-filter: blur(4px);
+}
+
+.offcanvas {
+  opacity: 0.55;
 }
 
 body { /* Safari, Chrome and Opera > 12.1 */ /* Firefox < 16 */ /* Internet Explorer */ /* Opera < 12.1 */

--- a/src/scss/Custom.scss
+++ b/src/scss/Custom.scss
@@ -6,7 +6,11 @@
 .offcanvas-backdrop.show {
   opacity: 1;
   background-color: rgba(15, 23, 42, 0.5);
-  backdrop-filter: blur(8px);
+  backdrop-filter: blur(4px);
+}
+
+.offcanvas {
+  opacity: 0.55;
 }
 
 body {

--- a/src/templates/nav.html
+++ b/src/templates/nav.html
@@ -14,12 +14,13 @@
       data-bs-toggle="offcanvas"
       data-bs-target="#offcanvasNavbar"
       aria-controls="offcanvasNavbar"
-      aria-label="Toggle navigation"
     >
       <span class="navbar-toggler-icon"></span>
     </button>
     <div
-      class="offcanvas offcanvas-end"
+      class="offcanvas offcanvas-start"
+      data-bs-backdrop="static"
+      data-bs-keyboard="true"
       tabindex="-1"
       id="offcanvasNavbar"
       aria-labelledby="offcanvasNavbarLabel"

--- a/travel.html
+++ b/travel.html
@@ -13,7 +13,6 @@
       rel="preload"
       src="../../node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
     ></script>
-    <script rel="preload" src="/src/scripts/nav.js"></script>
     <link rel="stylesheet" href="/src/scss/Custom.css" />
     <title>Travel</title>
   </head>

--- a/wedding-party.html
+++ b/wedding-party.html
@@ -13,7 +13,6 @@
       rel="preload"
       src="../../node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
     ></script>
-    <script rel="preload" src="/src/scripts/nav.js"></script>
     <link rel="stylesheet" href="/src/scss/Custom.css" />
     <title>Wedding Party</title>
   </head>


### PR DESCRIPTION
- Preloading nav.js seemed to do nothing but cause errors in the output, removing that as it is unnecessary. 
- Change backdrop to be static since we can't figure out why it won't dismiss on one click but dismisses on two.
- Made the offcanvas align on the left and made it semi transparent.
- Reduced blur to 4px instead of 8px because it subjectively looks better